### PR TITLE
run時に capture:false を指定するように変更

### DIFF
--- a/lib/grape/generator/cli.rb
+++ b/lib/grape/generator/cli.rb
@@ -88,7 +88,7 @@ module Grape
 
         def exec(commands)
           commands.map do |cmd|
-            run cmd, @config
+            run cmd, @config.merge(capture:false)
             raise "Failed in exec `#{cmd}`" unless $?.exitstatus == 0
           end
         end


### PR DESCRIPTION
bundle install が失敗したときのメッセージが判らないためコンソールに表示されるようにした。

更新前:

```
$ grape new example
      inside  /Users/suzumura/projects/example
      create    example/Gemfile
         run    bundle install --path vendor/bundle --without production from "./example"
     :
(stack trace)
     :
Failed in exec `bundle install --path vendor/bundle --without production`
```

更新後:

```
$ grape new example
      inside  /Users/suzumura/projects/example
      create    example/Gemfile
         run    bundle install --path vendor/bundle --without production from "./example"
Could not reach host bundler.rubygems.org. Check your network connection and try again.
     :
(stack trace)
     :
Failed in exec `bundle install --path vendor/bundle --without production`
```
